### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,30 @@
+---
+name: Bug
+about: Report a bug related to GroupVault
+labels: bug
+---
+
+**What happened?**
+
+**Did you expect to see some different?**
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Environment**
+
+* GroupVault version:
+
+    `Insert release version or Git SHA here`
+
+* Python version information:
+
+    `python3 --version`
+    <!-- Replace the command with its output above -->
+
+* Logs:
+
+    ```
+    insert logs relevant to the issue here
+    ```
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: If you want to propose a new feature or enhancement
+labels: enhancement
+---
+
+**What is missing?**
+
+**Why do we need it?**
+
+**Environment**
+
+* GroupVault version:
+
+    `Insert release version or Git SHA here`
+
+* Ansible version information:
+
+    `python3 --version`
+    <!-- Replace the command with its output above -->
+
+**Anything else we need to know?**:
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -14,7 +14,7 @@ labels: enhancement
 
     `Insert release version or Git SHA here`
 
-* Ansible version information:
+* Python version information:
 
     `python3 --version`
     <!-- Replace the command with its output above -->

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,28 @@
+---
+name: Support
+about: If you have questions about GroupVault
+labels: question
+---
+
+**What did you do?**
+
+**Did you expect to see some different?**
+
+**Environment**
+
+* GroupVault version:
+
+    `Insert release version or Git SHA here`
+
+* Python version information:
+
+    `python3 --version`
+    <!-- Replace the command with its output above -->
+
+* Logs:
+
+    ```
+    insert logs relevant to the issue here
+    ```
+
+**Anything else we need to know?**:


### PR DESCRIPTION
### Description
Adds multiple issue templates which can be used when raising GitHub issues.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ X ] All tests passing
- [ X ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
